### PR TITLE
Fix bridge near attachment position

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ mod_license = "LGPL-2.1"
 
 mc_version=1.21.1
 
-mod_version=4.0.2
+mod_version=4.0.3
 
 loader_version = 4
 neo_version = 21.1.92

--- a/src/main/java/com/mrtrollnugnug/ropebridge/handler/BridgeBuildingHandler.java
+++ b/src/main/java/com/mrtrollnugnug/ropebridge/handler/BridgeBuildingHandler.java
@@ -26,7 +26,7 @@ public class BridgeBuildingHandler {
 
 	public static void newBridge(Player player, ItemStack stack, BlockPos pos2) {
 		final LinkedList<SlabPosHandler> bridge = new LinkedList<>();
-		final BlockPos pos1 = BlockPos.containing(player.getX(), player.getY(), player.getZ()).below();
+		final BlockPos pos1 = player.blockPosition().below();
 		boolean allClear = true;
 		int x1;
 		int x2;

--- a/src/main/java/com/mrtrollnugnug/ropebridge/handler/BridgeBuildingHandler.java
+++ b/src/main/java/com/mrtrollnugnug/ropebridge/handler/BridgeBuildingHandler.java
@@ -24,29 +24,26 @@ public class BridgeBuildingHandler {
 	private BridgeBuildingHandler() {
 	}
 
-	public static void newBridge(Player player, ItemStack stack, BlockPos pos1, BlockPos pos2) {
+	public static void newBridge(Player player, ItemStack stack, BlockPos pos2) {
 		final LinkedList<SlabPosHandler> bridge = new LinkedList<>();
+		final BlockPos pos1 = BlockPos.containing(player.getX(), player.getY(), player.getZ()).below();
 		boolean allClear = true;
 		int x1;
 		int x2;
-		int y1;
-		int y2;
+		int y1 = pos1.getY();
+		int y2 = pos2.getY();
 		int z1;
 		int z2;
 		boolean rotate = getRotate(pos1, pos2);
 		if (!rotate) {
 			x1 = pos1.getX();
-			y1 = pos1.getY();
 			z1 = pos1.getZ();
 			x2 = pos2.getX();
-			y2 = pos2.getY();
 			z2 = pos2.getZ();
 		} else {
 			x1 = pos1.getZ();
-			y1 = pos1.getY();
 			z1 = pos1.getX();
 			x2 = pos2.getZ();
-			y2 = pos2.getY();
 			z2 = pos2.getX();
 		}
 		if (Math.abs(z2 - z1) > 3) {
@@ -73,8 +70,8 @@ public class BridgeBuildingHandler {
 			return;
 		}
 		for (int x = Math.min(x1, x2) + 1; x <= Math.max(x1, x2) - 1; x++) {
+			final double funcVal = m * x + b - distance / 1000 * Math.sin((x - Math.min(x1, x2)) * (Math.PI / distance)) * ConfigHandler.getBridgeDroopFactor() + ConfigHandler.getBridgeYOffset();
 			for (int y = Math.max(y1, y2); y >= Math.min(y1, y2) - distInt / 8 - 1; y--) {
-				final double funcVal = m * x + b - distance / 1000 * Math.sin((x - Math.min(x1, x2)) * (Math.PI / distance)) * ConfigHandler.getBridgeDroopFactor() + ConfigHandler.getBridgeYOffset();
 				if (y + 0.5 > funcVal && y - 0.5 <= funcVal) {
 					int level;
 					if (funcVal >= y) {

--- a/src/main/java/com/mrtrollnugnug/ropebridge/item/ItemBridgeBuilder.java
+++ b/src/main/java/com/mrtrollnugnug/ropebridge/item/ItemBridgeBuilder.java
@@ -76,9 +76,8 @@ public class ItemBridgeBuilder extends ItemBuilder {
 				} else {
 					final HitResult hit = trace(player);
 					if (hit instanceof BlockHitResult blockHitResult) {
-						final BlockPos floored = BlockPos.containing(player.getX(), player.getY() - 1, player.getZ()).below();
 						BlockPos target = blockHitResult.getBlockPos();
-						BridgeBuildingHandler.newBridge(player, player.getMainHandItem(), floored, target);
+						BridgeBuildingHandler.newBridge(player, player.getMainHandItem(), target);
 						level.playSound((Player) null, player.getX(), player.getY(), player.getZ(), ContentHandler.swoosh.get(), SoundSource.PLAYERS, 1.0F, 1.0F / (level.getRandom().nextFloat() * 0.5F + 1.0F) + 0.2F);
 					}
 				}


### PR DESCRIPTION
using `.below()` already gets the block under the player, so subtracting 1 from .getY() was resulting in starting 2 blocks down instead of from the block the player is on. This was especially noticeable when making very short bridges.

Also refactored `newBridge(..)` to remove a redundant parameter, and made the slab placement loop slightly more efficient by calculating `funcVal` in the outer loop. 